### PR TITLE
Add aspect controls and macOS app packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # SunPad
 
 <p align="center">
-  <strong>Super Mario Sunshine on iPhone and iPad through static recompilation and Metal.</strong><br>
-  Native landscape rendering, touch controls, controller support, and Files-based game-data setup.
+  <strong>Super Mario Sunshine on iPhone, iPad, and Apple Silicon Mac through static recompilation and Metal.</strong><br>
+  Touch controls on mobile, keyboard/controller input on Mac, and local user-supplied game-data setup.
 </p>
 
 <p align="center">
@@ -11,6 +11,7 @@
 
 <p align="center">
   <img alt="iOS 16+" src="https://img.shields.io/badge/iOS%20%2F%20iPadOS-16%2B-0A84FF?logo=apple">
+  <img alt="macOS 14+" src="https://img.shields.io/badge/macOS-14%2B-0A84FF?logo=apple">
   <img alt="Metal renderer" src="https://img.shields.io/badge/renderer-Metal-5E5CE6">
   <img alt="Ahead-of-time static recompilation" src="https://img.shields.io/badge/PowerPC-static%20recompilation-FF9F0A">
   <img alt="Physical iPad tested" src="https://img.shields.io/badge/physical%20iPad-tested-30D158">
@@ -25,9 +26,11 @@ Sunshine module and the ModernGekko/Dolphin-derived compatibility runtime.
 The original PowerPC code runs as ahead-of-time recompiled host code, without
 a runtime PowerPC JIT, while Dolphin's Metal backend renders into the iOS app.
 
-The app imports a user-provided supported GameCube image through Files,
+The mobile app imports a user-provided supported GameCube image through Files,
 extracts it on-device, and provides a landscape touch controller alongside
-iOS GameController support. This repository contains the Apple integration,
+iOS GameController support. The local macOS app provides a Metal launcher,
+internal-resolution and fullscreen options, keyboard controls, and controller
+selection. This repository contains the Apple integration,
 patches, and reproducible tooling. It does **not** contain Super Mario
 Sunshine, a GameCube image, extracted Nintendo assets, saves, or a generated
 game module.
@@ -36,20 +39,24 @@ game module.
 
 | Area | Current result |
 |---|---|
-| Native app | Universal arm64 iPhone/iPad target for iOS and iPadOS 16+ |
+| Native app | Universal arm64 iPhone/iPad target plus a local Apple Silicon `SunPad.app` packager |
 | Rendering | Dolphin Metal backend reaches the title sequence and playable Delfino Plaza gameplay |
 | Game setup | Files picker, GMSE01 validation, private retention, and on-device extraction work |
 | Touch | Move stick, C-stick, D-pad, A/B/X/Y/Z, L/R, Start, and a persistent settings menu |
-| Controllers | Touch and iOS GameController input merge through one normalized GameCube state |
-| Settings | Live 1×–4× render scale, control opacity/size, hide-on-controller, and movable layouts |
+| Controllers | Touch and iOS GameController on mobile; keyboard or connected controller on macOS |
+| Settings | Live 1×–4× render scale, original 4:3 plus experimental widescreen/fill modes, and touch-layout settings |
 | Audio | Guest-timebase defect fixed; continuous desktop and Simulator audio verified; fresh physical-device audio acceptance remains |
 | Distribution | Source/development build only; no public IPA, TestFlight, or App Store release |
 
-The current development build has been signed, installed, and played on a
+The mobile development build has been signed, installed, and played on a
 12.9-inch iPad Pro (6th generation). Physical-device boot, Metal rendering,
 Files import, on-device extraction, touch input, gameplay, and in-place app
-updates have been exercised. See [the testing ledger](docs/TESTING.md) for the
-dated evidence and the checks that remain.
+updates have been exercised. A signed development build has also launched on
+an iPhone 14, where performance is currently below the iPad experience even at
+1×. The local arm64 macOS app bundle has been built, signed ad hoc, and
+launched with its Metal and keyboard defaults. See
+[the testing ledger](docs/TESTING.md) for the dated evidence and remaining
+hands-on acceptance checks.
 
 ## Get started
 
@@ -85,11 +92,23 @@ xcodebuild -project SunPad.xcodeproj -scheme SunPad -configuration Debug \
   -allowProvisioningUpdates build
 ```
 
+Build the local Apple Silicon macOS app after producing the desktop GMSE01
+module from [`docs/BUILDING.md`](docs/BUILDING.md):
+
+```sh
+./scripts/package-macos-app.sh
+open build-macos/SunPad.app
+```
+
+The local package may contain your locally generated game module. The package
+is ignored, is not a release artifact, and must not be committed or
+distributed.
+
 Generated source trees, build products, GameCube data, saves, signing
 material, and locally recompiled modules are ignored and must never be
 committed.
 
-## First launch
+## First launch on iPhone or iPad
 
 SunPad never downloads or bundles game data.
 
@@ -103,6 +122,16 @@ SunPad validates the GameCube header and `GMSE01` game code before replacing
 the retained image. The private copy and extracted tree stay in the app
 container and are reused on later launches.
 
+## First launch on Mac
+
+Open the locally built `SunPad.app`, choose your legally obtained supported
+disc image, then use **Extract and Play**. The launcher uses Metal and offers
+internal-resolution and fullscreen options. It starts with keyboard controls:
+WASD to move, arrow keys for the camera, J/K/U/I/O for A/B/X/Y/Z, Q/E for L/R,
+and Return for Start. Connect a controller and choose it in the launcher to
+replace the keyboard profile. Mac game data, configuration, and saves stay in
+`~/Library/Application Support/SunPad`.
+
 ## Touch controls
 
 SunPad uses a landscape layout designed separately for compact iPhones and
@@ -110,8 +139,9 @@ larger iPads:
 
 - **Left:** movement stick, D-pad, and L within thumb reach.
 - **Right:** camera stick, A/B/X/Y diamond, Z, R, and Start.
-- **Menu:** the persistent **•••** button opens render, control, game-data,
-  and save settings.
+- **Menu:** the persistent **•••** button opens render resolution, aspect
+  ratio, control, game-data, and save settings. Original 4:3 is the default;
+  16:9 and Fill Screen are marked experimental.
 - **Customize:** Move mode lets controls be dragged and saves normalized
   positions per device class; Reset restores the default layout.
 - **Controller handoff:** a connected physical controller can hide the touch
@@ -206,9 +236,9 @@ No save belongs in Git or a release artifact.
 ### Is everything finished?
 
 No. The current build is playable and useful for development testing, but
-physical-device audio re-acceptance, broader scene coverage, lifecycle/save
-hardening, compressed image support, distribution packaging, and the native
-macOS shell remain explicit work.
+physical-device audio re-acceptance, iPhone performance, broader scene
+coverage, lifecycle/save hardening, compressed image support, distribution
+packaging, and broader macOS gameplay acceptance remain explicit work.
 
 ## Project map
 
@@ -216,7 +246,9 @@ macOS shell remain explicit work.
 |---|---|
 | [`scripts/ios-build-core.sh`](scripts/ios-build-core.sh) | Build and provision the Simulator core/module |
 | [`scripts/ios-build-core-device.sh`](scripts/ios-build-core-device.sh) | Build and provision the physical-device core/module |
+| [`scripts/package-macos-app.sh`](scripts/package-macos-app.sh) | Build the local Apple Silicon `SunPad.app` bundle |
 | [`apple/ios/`](apple/ios/) | UIKit app shell, Files import, touch UI, and Apple adapter |
+| [`apple/macos/`](apple/macos/) | macOS bundle metadata, launcher wrapper, and keyboard defaults |
 | [`patches/ModernGekko-dolphin/`](patches/ModernGekko-dolphin/) | Maintained upstream runtime fixes |
 | [`docs/BUILDING.md`](docs/BUILDING.md) | Exact desktop, Simulator, and device build commands |
 | [`docs/TESTING.md`](docs/TESTING.md) | Dated evidence and remaining acceptance gates |

--- a/apple/ios/SunPadCoreHost.h
+++ b/apple/ios/SunPadCoreHost.h
@@ -4,6 +4,7 @@
 #import <UIKit/UIKit.h>
 
 #include "SunPadInputState.h"
+#import "SunPadSettings.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -38,6 +39,10 @@ NS_ASSUME_NONNULL_BEGIN
 /* Applies the render-resolution scale (1 = native GameCube EFB, 2..4 = scale)
  * to the running runtime. Safe to call from any thread. */
 - (void)setRenderScale:(NSInteger)scale;
+
+/* Applies the output aspect ratio without resizing the Metal view or touch
+ * overlay. Safe to call from any thread. */
+- (void)setAspectRatioMode:(SunPadAspectRatioMode)mode;
 
 /* Current emulated FPS from the runtime (0 if not booted). */
 - (double)currentFPS;

--- a/apple/ios/SunPadCoreHost.mm
+++ b/apple/ios/SunPadCoreHost.mm
@@ -6,6 +6,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cmath>
 #include <cstdio>
 #include <cstring>
 #include <filesystem>
@@ -20,6 +21,11 @@ namespace fs = std::filesystem;
 #include "Core/Config/GraphicsSettings.h"
 #include "Core/System.h"
 #include "VideoCommon/PerformanceMetrics.h"
+#include "VideoCommon/VideoConfig.h"
+
+@interface SunPadCoreHost ()
+- (void)applyAspectRatioMode:(SunPadAspectRatioMode)mode;
+@end
 
 @implementation SunPadCoreHost {
     CAMetalLayer *_layer;
@@ -160,6 +166,12 @@ namespace fs = std::filesystem;
                            static_cast<int>(savedScale < 1 ? 1 : (savedScale > 4 ? 4 : savedScale)));
         Config::SetCurrent(Config::GFX_MAX_EFB_SCALE, 12);
 
+        NSNumber *savedAspectValue = [[NSUserDefaults standardUserDefaults]
+            objectForKey:@"SunPadAspectRatioMode"];
+        SunPadAspectRatioMode savedAspect = savedAspectValue ?
+            (SunPadAspectRatioMode)savedAspectValue.integerValue : SunPadAspectRatioOriginal;
+        [self applyAspectRatioMode:savedAspect];
+
         // Open the input FIFO for writing (blocks until the runtime reads it).
         NSString *pipePath = [[userDirectory stringByAppendingPathComponent:@"Pipes"]
             stringByAppendingPathComponent:@"sunpad"];
@@ -240,6 +252,36 @@ namespace fs = std::filesystem;
     // Config::SetCurrent is mutex-protected and the video backend refreshes
     // g_ActiveConfig on the next config callback.
     Config::SetCurrent(Config::GFX_EFB_SCALE, static_cast<int>(clamped));
+}
+
+- (void)applyAspectRatioMode:(SunPadAspectRatioMode)mode {
+    switch (mode) {
+    case SunPadAspectRatioWidescreen:
+        Config::SetCurrent(Config::GFX_ASPECT_RATIO, AspectMode::ForceWide);
+        Config::SetCurrent(Config::GFX_WIDESCREEN_HACK, true);
+        break;
+    case SunPadAspectRatioFillScreen: {
+        CGSize size = _layer.drawableSize;
+        int width = MAX(1, (int)std::lround(size.width));
+        int height = MAX(1, (int)std::lround(size.height));
+        Config::SetCurrent(Config::GFX_CUSTOM_ASPECT_RATIO_WIDTH, width);
+        Config::SetCurrent(Config::GFX_CUSTOM_ASPECT_RATIO_HEIGHT, height);
+        Config::SetCurrent(Config::GFX_ASPECT_RATIO, AspectMode::CustomStretch);
+        Config::SetCurrent(Config::GFX_WIDESCREEN_HACK, true);
+        break;
+    }
+    case SunPadAspectRatioOriginal:
+    default:
+        Config::SetCurrent(Config::GFX_ASPECT_RATIO, AspectMode::ForceStandard);
+        Config::SetCurrent(Config::GFX_WIDESCREEN_HACK, false);
+        break;
+    }
+}
+
+- (void)setAspectRatioMode:(SunPadAspectRatioMode)mode {
+    if (!_running->load())
+        return; // Runtime not booted yet; the mode applies at boot.
+    [self applyAspectRatioMode:mode];
 }
 
 - (double)currentFPS {

--- a/apple/ios/SunPadGameOverlay.mm
+++ b/apple/ios/SunPadGameOverlay.mm
@@ -215,6 +215,12 @@
         [self renderAction:@"4×" scale:4],
     ]];
 
+    UIMenu *aspectMenu = [UIMenu menuWithTitle:@"Aspect Ratio" children:@[
+        [self aspectRatioAction:@"Original 4:3" mode:SunPadAspectRatioOriginal],
+        [self aspectRatioAction:@"16:9 (Experimental)" mode:SunPadAspectRatioWidescreen],
+        [self aspectRatioAction:@"Fill Screen (Experimental)" mode:SunPadAspectRatioFillScreen],
+    ]];
+
     UIMenu *dataMenu = [UIMenu menuWithTitle:@"Game Data & Saves" children:@[
         [UIAction actionWithTitle:@"Change or Reimport Game Data"
                             image:[UIImage systemImageNamed:@"arrow.triangle.2.circlepath"]
@@ -244,6 +250,7 @@
 
     return [UIMenu menuWithTitle:@"SunPad" children:@[
         renderMenu,
+        aspectMenu,
         fpsAction,
         [UIAction actionWithTitle:@"Touch Control Settings…"
                             image:[UIImage systemImageNamed:@"hand.draw"]
@@ -253,6 +260,23 @@
         }],
         dataMenu,
     ]];
+}
+
+- (UIAction *)aspectRatioAction:(NSString *)title mode:(SunPadAspectRatioMode)mode {
+    __weak SunPadGameOverlay *weakSelf = self;
+    UIAction *aspectAction = [UIAction actionWithTitle:title
+                                                 image:nil
+                                            identifier:nil
+                                               handler:^(__kindof UIAction *action) {
+        (void)action;
+        [SunPadSettings sharedSettings].aspectRatioMode = mode;
+        [[SunPadSettings sharedSettings] synchronize];
+        [[[UISelectionFeedbackGenerator alloc] init] selectionChanged];
+        [weakSelf refreshMenuButton];
+    }];
+    aspectAction.state = [SunPadSettings sharedSettings].aspectRatioMode == mode ?
+        UIMenuElementStateOn : UIMenuElementStateOff;
+    return aspectAction;
 }
 
 - (UIAction *)renderAction:(NSString *)title scale:(NSInteger)scale {

--- a/apple/ios/SunPadGameViewController.mm
+++ b/apple/ios/SunPadGameViewController.mm
@@ -222,7 +222,9 @@ static constexpr CGFloat SunPadDrawableScale = 1.0;
 
 - (void)settingsChanged:(NSNotification *)notification {
     (void)notification;
-    [_coreHost setRenderScale:[SunPadSettings sharedSettings].renderScale];
+    SunPadSettings *settings = [SunPadSettings sharedSettings];
+    [_coreHost setRenderScale:settings.renderScale];
+    [_coreHost setAspectRatioMode:settings.aspectRatioMode];
     [self updateFPSLabel];
 }
 

--- a/apple/macos/Info.plist
+++ b/apple/macos/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleDisplayName</key>
+    <string>SunPad</string>
+    <key>CFBundleExecutable</key>
+    <string>SunPad</string>
+    <key>CFBundleIconFile</key>
+    <string>AppIcon.png</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.sunpad.SunPad.macos</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>SunPad</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>14.0</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>NSHumanReadableCopyright</key>
+    <string>Unofficial community project; game data not included.</string>
+</dict>
+</plist>

--- a/apple/macos/SunPad
+++ b/apple/macos/SunPad
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONTENTS="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+export XDG_DATA_HOME="$HOME/Library/Application Support"
+USER_DIR="$XDG_DATA_HOME/SunPad"
+
+mkdir -p "$USER_DIR/Config"
+if [[ ! -f "$USER_DIR/config.ini" ]]; then
+  cp "$CONTENTS/Resources/default-config.ini" "$USER_DIR/config.ini"
+fi
+if [[ ! -f "$USER_DIR/Config/GCPadNew.ini" ]]; then
+  cp "$CONTENTS/Resources/default-GCPadNew.ini" "$USER_DIR/Config/GCPadNew.ini"
+fi
+
+exec "$CONTENTS/MacOS/SunPadFrontend"

--- a/apple/macos/default-GCPadNew.ini
+++ b/apple/macos/default-GCPadNew.ini
@@ -1,0 +1,30 @@
+[GCPad1]
+Device = Quartz/0/Keyboard & Mouse
+Buttons/A = J
+Buttons/B = K
+Buttons/X = U
+Buttons/Y = I
+Buttons/Z = O
+Buttons/Start = Return
+Main Stick/Up = W
+Main Stick/Down = S
+Main Stick/Left = A
+Main Stick/Right = D
+Main Stick/Calibration = 100.00
+C-Stick/Up = `Up Arrow`
+C-Stick/Down = `Down Arrow`
+C-Stick/Left = `Left Arrow`
+C-Stick/Right = `Right Arrow`
+C-Stick/Calibration = 100.00
+Triggers/L = Q
+Triggers/R = E
+Triggers/L-Analog = Q
+Triggers/R-Analog = E
+D-Pad/Up = T
+D-Pad/Down = G
+D-Pad/Left = F
+D-Pad/Right = H
+
+[GCPad2]
+[GCPad3]
+[GCPad4]

--- a/apple/macos/default-config.ini
+++ b/apple/macos/default-config.ini
@@ -1,0 +1,14 @@
+# SunPad desktop settings
+# Resolution is Dolphin's internal render target, not the window size.
+[Video]
+resolution=1920x1080
+backend=Metal
+fullscreen=false
+show_fps_in_title=true
+[Input]
+controller1=Quartz/0/Keyboard & Mouse
+[Netplay]
+nickname=Player
+address=127.0.0.1
+port=2626
+buffer=auto

--- a/apple/shared/SunPadSettings.h
+++ b/apple/shared/SunPadSettings.h
@@ -4,6 +4,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSInteger, SunPadAspectRatioMode) {
+    SunPadAspectRatioOriginal = 0,
+    SunPadAspectRatioWidescreen = 1,
+    SunPadAspectRatioFillScreen = 2,
+};
+
 /* Persisted SunPad settings shared by macOS, iOS, and iPadOS. Stored in
  * NSUserDefaults so each platform keeps the same user-facing options.
  */
@@ -14,6 +20,10 @@ NS_ASSUME_NONNULL_BEGIN
 /* Render-resolution scale. 1 = native GameCube EFB, 2..4 = multiplier. */
 @property(nonatomic, assign) NSInteger renderScale;
 - (float)renderScaleFloat;
+
+/* Output aspect ratio. Original 4:3 is the stable default; wider modes are
+ * experimental and affect only game rendering, never touch-control layout. */
+@property(nonatomic, assign) SunPadAspectRatioMode aspectRatioMode;
 
 /* Optional developer performance overlay. Off by default for normal play. */
 @property(nonatomic, assign) BOOL showFPSCounter;

--- a/apple/shared/SunPadSettings.mm
+++ b/apple/shared/SunPadSettings.mm
@@ -45,6 +45,22 @@
     }
 }
 
+- (SunPadAspectRatioMode)aspectRatioMode {
+    NSInteger mode = [[NSUserDefaults standardUserDefaults]
+        integerForKey:@"SunPadAspectRatioMode"];
+    if (mode < SunPadAspectRatioOriginal || mode > SunPadAspectRatioFillScreen)
+        return SunPadAspectRatioOriginal;
+    return (SunPadAspectRatioMode)mode;
+}
+
+- (void)setAspectRatioMode:(SunPadAspectRatioMode)aspectRatioMode {
+    NSInteger mode = aspectRatioMode;
+    if (mode < SunPadAspectRatioOriginal || mode > SunPadAspectRatioFillScreen)
+        mode = SunPadAspectRatioOriginal;
+    [[NSUserDefaults standardUserDefaults] setInteger:mode
+                                               forKey:@"SunPadAspectRatioMode"];
+}
+
 - (BOOL)showFPSCounter {
     return [[NSUserDefaults standardUserDefaults] boolForKey:@"SunPadShowFPSCounter"];
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Last updated: 2026-08-06
+Last updated: 2026-08-08
 
 ## Goal architecture
 
@@ -16,7 +16,7 @@ User-owned GMSE01 disc image
         ▼
  ModernGekko / shared GameCube compatibility runtime
         │
-        ├── macOS app shell (Stage 2, pending)
+        ├── macOS app bundle (launcher + runner)
         ├── iOS app shell (SunPad.xcodeproj)
         └── iPadOS app shell (same universal target)
 ```
@@ -31,7 +31,7 @@ sunpad/
   apple/
     shared/             SunPadSettings, SunPadInputState (macOS+iOS)
     ios/                UIKit app, game overlay, core host, Xcode assets
-    macos/              (future macOS app)
+    macos/              macOS bundle metadata, wrapper, and keyboard defaults
   SunPad.xcodeproj      universal iPhone/iPad target
   ref/                  external clones + local disc (gitignored wholesale; see docs/DEPENDENCIES.md)
   tests/                test index and harness pointers (see docs/TESTING.md)

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -1,6 +1,6 @@
 # Building
 
-Last updated: 2026-08-07
+Last updated: 2026-08-08
 
 ## Prerequisites
 
@@ -22,6 +22,16 @@ ninja -C lib/ModernGekko/build moderngekko-port moderngekko-run -j8
 ./lib/ModernGekko/build/moderngekko-run --game extracted/Super-Mario-Sunshine \
   --module "$(cat build/modules/GMSE01/active-module.txt)" --graphics Metal
 ```
+
+Package the proven desktop outputs as a local Apple Silicon app:
+
+```sh
+./scripts/package-macos-app.sh
+open build-macos/SunPad.app
+```
+
+This local bundle includes the locally generated module but no disc image or
+save. It is gitignored and must not be distributed.
 
 ## iOS / iPadOS Simulator build (proven)
 

--- a/docs/IOS_IPADOS.md
+++ b/docs/IOS_IPADOS.md
@@ -1,6 +1,6 @@
 # iOS and iPadOS
 
-Last updated: 2026-08-07
+Last updated: 2026-08-08
 
 ## Current status
 
@@ -19,7 +19,8 @@ and renders on a physical iPad; game-engine audio is the major open defect.
 - `SunPadCoreHost` — boots the game on a background thread, owns the
   CAMetalLayer surface and the pipe-input bridge.
 - `SunPadGameOverlay` — BellPad-inspired overlay: three-dot menu with render
-  resolution (1× native/2×/3×/4×), touch-control settings (opacity, size,
+  resolution (1× native/2×/3×/4×), aspect ratio (original 4:3 plus experimental
+  16:9 and Fill Screen), touch-control settings (opacity, size,
   hide-on-controller, edit-layout, reset), Game Data & Saves actions.
 - Sunshine touch controls: main stick, C-stick, A/B/X/Y/Z/Start/L/R.
 - Shared settings (`SunPadSettings`) and normalized input
@@ -50,6 +51,9 @@ initial buffers. THP video audio follows a separate CPU-mixed path and can
 remain audible. See [AUDIO_ISSUE.md](AUDIO_ISSUE.md) before changing output
 buffering again. The persisted 1×-4× render-resolution choice is applied live
 through `Config::GFX_EFB_SCALE` (at boot and on change).
+Aspect changes are applied through Dolphin's graphics config without resizing
+the Metal surface or its separate UIKit touch overlay, so control placement is
+unchanged. Original 4:3 is the default on iPhone and iPad.
 
 ## Game data on mobile
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,6 +1,6 @@
 # Known Issues
 
-Last updated: 2026-08-07
+Last updated: 2026-08-08
 
 ## iOS / iPadOS
 
@@ -31,6 +31,17 @@ Last updated: 2026-08-07
 7. **Physical-controller acceptance pending** — touch controls have been used
    on a physical iPad, but connect/disconnect and auto-hide behavior still need
    hands-on controller coverage.
+8. **Physical iPhone performance is less than ideal** — an iPhone 14 can run
+   substantially below full speed even at 1×. The runtime and module are
+   release-optimized; the portable software vertex loader and interpreter
+   fallback remain likely CPU costs. Profile native dispatch and fallback
+   counters before attempting device-specific tuning. The current iPad target
+   provides the better mobile experience.
+9. **Experimental wide output** — Original 4:3 is the stable default on both
+   iPhone and iPad. The 16:9 and Fill Screen menu choices use Dolphin's
+   widescreen/custom-aspect paths and can expose projection, culling, or
+   stretching defects. They change game rendering only; touch controls keep
+   their normal device layout.
 
 ## Desktop Stage 1 gaps
 

--- a/docs/MACOS.md
+++ b/docs/MACOS.md
@@ -1,28 +1,55 @@
 # macOS
 
-Last updated: 2026-08-06
-
-Stage 2 target: native Apple Silicon `SunPad.app`.
+Last updated: 2026-08-08
 
 ## Current status
 
-Not started. Stage 1 desktop reproduction is proven through the title/intro
-sequences (extract → recompile with 0 unknown ops → arm64 module →
-`moderngekko-run` at ~30 FPS with Metal and pipe input); the remaining Stage 1
-gates are plaza gameplay, objective completion, and save/reload evidence.
-The native `SunPad.app` shell is built on top of the shared Apple runtime once
-those gates close.
+Implemented as a local Apple Silicon `SunPad.app` around the existing native
+ModernGekko launcher and runner. The bundle is arm64, uses Metal, exposes
+internal-resolution and fullscreen settings, imports/extracts a user-selected
+supported disc image, and launches the locally generated GMSE01 module.
 
-## Intended properties
+The 2026-08-08 package was built, ad-hoc signed, verified with `codesign`, and
+launched as a live GUI process. This proves the app shell and setup path; plaza
+gameplay, objective completion, save/reload, and extended-session acceptance
+remain open desktop gates.
+
+## Build and run
+
+After completing the desktop extraction/recompilation steps in
+[BUILDING.md](BUILDING.md):
+
+```sh
+./scripts/package-macos-app.sh
+open build-macos/SunPad.app
+```
+
+The output bundle and its locally generated game module are ignored local
+artifacts and must not be committed or distributed.
+
+## Controls and data
+
+- WASD: main stick
+- Arrow keys: C-stick / camera
+- J/K/U/I/O: A/B/X/Y/Z
+- Q/E: L/R
+- Return: Start
+- T/G/F/H: D-pad
+
+A connected SDL-compatible controller can replace the keyboard profile from
+the launcher. Configuration, extracted game data, saves, logs, and controller
+profiles live under `~/Library/Application Support/SunPad`.
+
+## Current properties
 
 - ARM64 process, no Rosetta, no PowerPC JIT product path
 - Metal-preferred rendering through the compatibility runtime where available
-- GameController + keyboard
+- Connected controller + keyboard
 - Memory-card save persistence
-- Native menus inspired by BellPad
+- Native app bundle with the existing ModernGekko launcher UI
 - Clear errors for missing/invalid game data
 - Runtime/crash logs
 
-## Gate criteria
+## Remaining gate criteria
 
 See the Stage 2 checklist in the project goal / [STATUS.md](STATUS.md).

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Status
 
-Last updated: 2026-08-07
+Last updated: 2026-08-08
 
 Current phase: **SunPad now boots Super Mario Sunshine on a physical iPad as
 well as the iPhone and iPad simulators** as an ahead-of-time statically
@@ -31,7 +31,7 @@ code-generating loader).
 | Stage | Goal | Status |
 |---|---|---|
 | 1 | Reproduce Sunshine recompilation to playable desktop session | **In progress — title/intro/input proven; plaza/objective/save open** |
-| 2 | Native Apple Silicon macOS `.app` proof | Not started (moderngekko-run is the current desktop shell) |
+| 2 | Native Apple Silicon macOS `.app` proof | **App bundle built, signed, and launched; gameplay acceptance remains** |
 | 3 | Mobile-runtime hardening | **In progress — Simulator/device core built; JIT disabled; interpreter + software-vertex fallbacks** |
 | 4 | iPhone + iPad apps | **In progress — physical iPad boot/render/input proven; audio blocker open** |
 
@@ -55,7 +55,9 @@ code-generating loader).
    written to the Dolphin pipe device and advances the game (START presses
    moved the game from the title into gameplay rendering).
 7. BellPad-inspired overlay: three-dot menu, 1x native/2x/3x/4x render
-   resolution, touch controls, opacity/size/hide/edit-layout settings.
+   resolution, original 4:3 plus experimental 16:9/Fill Screen output, touch
+   controls, opacity/size/hide/edit-layout settings. Aspect changes do not
+   move the separate touch overlay.
 8. No runtime PowerPC JIT on iOS: interpreter fallback + software vertex
    loader.
 9. **On-device game-data import** is implemented and verified: document
@@ -83,6 +85,10 @@ code-generating loader).
 3. Host module packaging: arm64 `gGMSE01_recomp.dylib`.
 4. `moderngekko-run` launches on Apple Silicon with Metal at 30 FPS through
    the title/intro sequences and responds to pipe input.
+5. A local arm64 `SunPad.app` packages the native launcher/runner/module,
+   defaults to Metal, exposes resolution/fullscreen settings, seeds WASD +
+   keyboard controls, and allows a connected controller profile to replace
+   them. The app bundle passes ad-hoc signing verification and launches.
 
 ## What does not work / not yet proven
 
@@ -100,7 +106,8 @@ code-generating loader).
 - Physical-iPad signing, install, launch, Metal rendering, ISO boot, and touch
   input are proven. Broader performance and memory acceptance remain open.
 - Desktop Stage 1: plaza gameplay, objective completion, save/reload evidence.
-- No SunPad-native macOS app shell yet.
+- The macOS app shell is proven, but plaza gameplay, objective completion,
+  save/reload, and extended-session acceptance remain open.
 - Touch controls are usable on physical iPad, including move mode, individual
   sizing, opacity, GameCube-style colors, and a closable settings panel.
 - App lifecycle hardening is partial: backgrounding/pause hooks exist but
@@ -116,8 +123,8 @@ code-generating loader).
    (game-ID matching against the provisioned module).
 3. App lifecycle: save flushing before suspension, audio-interruption
    restoration, controller connect/disconnect during gameplay.
-4. Stage 2: native macOS SunPad `.app` shell on the shared runtime layer.
-5. Desktop Stage 1 gates: plaza gameplay, objective, save/reload evidence.
+4. Desktop/macOS app gates: plaza gameplay, objective, save/reload, connected
+   controller, and extended-session evidence.
 
 ## Evidence locations (local, gitignored)
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,6 +1,6 @@
 # Testing
 
-Last updated: 2026-08-07
+Last updated: 2026-08-08
 
 ## Principles
 
@@ -116,3 +116,15 @@ Jit64-only).
 | Load playable area | Partial | airstrip gameplay reached on desktop; plaza pending |
 | Objective / save / reload | Pending | |
 | Extended session | Partial | multi-minute holds; multi-hour not done |
+
+## macOS app evidence (2026-08-08)
+
+| Check | Result | Evidence |
+|---|---|---|
+| Local `SunPad.app` package | Pass | `scripts/package-macos-app.sh` completed |
+| Apple Silicon binaries | Pass | launcher, runner, and local GMSE01 module are arm64 Mach-O |
+| Bundle signing | Pass | ad-hoc `codesign --verify --deep --strict` |
+| GUI launch | Pass | `SunPadFrontend` live from the app bundle |
+| Desktop defaults | Pass | Metal, 1920×1080 internal resolution, Quartz keyboard profile |
+| Keyboard mapping | Configured | WASD movement, arrow camera, face/trigger/Start/D-pad keys; hands-on gameplay acceptance remains |
+| Connected controller | Configured | launcher can replace the keyboard profile; hands-on acceptance remains |

--- a/patches/ModernGekko/0001-macos-metal-frontend.patch
+++ b/patches/ModernGekko/0001-macos-metal-frontend.patch
@@ -1,0 +1,38 @@
+diff --git a/tools/frontend_config.cpp b/tools/frontend_config.cpp
+--- a/tools/frontend_config.cpp
++++ b/tools/frontend_config.cpp
+@@ -39,6 +39,10 @@ std::string NormalizeGraphicsBackend(std::string value) {
+   if (lower == "vulkan")
+     return "Vulkan";
+   if (lower == "opengl" || lower == "ogl")
+     return "OGL";
++#if defined(__APPLE__)
++  if (lower == "metal")
++    return "Metal";
++#endif
+   return {};
+ }
+@@ -87,6 +91,10 @@ const std::vector<GraphicsBackendOption> &SupportedGraphicsBackends() {
++#if defined(__APPLE__)
++  static const std::vector<GraphicsBackendOption> backends = {{"Metal", "Metal"}};
++#else
+   static const std::vector<GraphicsBackendOption> backends = {
+       {"Vulkan", "Vulkan"},
+       {"OpenGL", "OGL"},
+   };
++#endif
+   return backends;
+ }
+diff --git a/tools/frontend_config.hpp b/tools/frontend_config.hpp
+--- a/tools/frontend_config.hpp
++++ b/tools/frontend_config.hpp
+@@ -22,5 +22,9 @@ struct ConfigResult {
+   int dolphin_scale = 0;
+   std::string resolution;
++#if defined(__APPLE__)
++  std::string graphics_backend = "Metal";
++#else
+   std::string graphics_backend = "Vulkan";
++#endif
+   std::string controller;
+   std::vector<std::string> controllers;

--- a/patches/README.md
+++ b/patches/README.md
@@ -11,6 +11,12 @@ SunPad-owned patches, kept separate from generic upstream tooling:
 
 ## Applied patches
 
+`ModernGekko/` holds small SunPad-owned frontend deltas against the
+ModernGekko root:
+
+- `0001-macos-metal-frontend.patch` — exposes Metal as the only graphics
+  backend in the macOS launcher and makes it the desktop default.
+
 `ModernGekko-dolphin/` holds the SunPad-owned deltas against the vendored
 Dolphin (`ref/ModernGekko/vendor/dolphin`). They are generic runtime patches,
 not Sunshine-specific:

--- a/scripts/package-macos-app.sh
+++ b/scripts/package-macos-app.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Builds a local Apple Silicon SunPad.app. The generated game module is copied
+# only into the ignored local bundle and must never be committed or distributed.
+set -euo pipefail
+
+ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+MG="$ROOT/ref/ModernGekko"
+TPL="$ROOT/ref/ModernGekko-Template"
+BUILD="${SUNPAD_MACOS_BUILD_DIR:-$MG/build-desktop}"
+OUTPUT="${SUNPAD_MACOS_OUTPUT:-$ROOT/build-macos/SunPad.app}"
+PATCH="$ROOT/patches/ModernGekko/0001-macos-metal-frontend.patch"
+
+if git -C "$MG" apply --reverse --check "$PATCH" >/dev/null 2>&1; then
+  : # Already applied.
+elif git -C "$MG" apply --check "$PATCH" >/dev/null 2>&1; then
+  git -C "$MG" apply "$PATCH"
+else
+  echo "ModernGekko macOS frontend patch does not apply cleanly." >&2
+  exit 1
+fi
+
+cmake -S "$MG" -B "$BUILD" -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DMODERNGEKKO_FRONTEND_NAME=SunPad \
+  -DMODERNGEKKO_LAUNCHER_OUTPUT_NAME=SunPadFrontend \
+  -DMODERNGEKKO_RUNNER_OUTPUT_NAME=SunPadRunner \
+  -DMODERNGEKKO_USER_DIRECTORY_NAME=SunPad \
+  -DMODERNGEKKO_DEFAULT_WINDOW_TITLE=SunPad \
+  -DMODERNGEKKO_LOG_FILENAME=SunPad.log \
+  -DMODERNGEKKO_GAMECUBE_CONTROLLERS=ON \
+  -DMODERNGEKKO_REQUIRED_DISC_ID=GMSE01 \
+  -DENABLE_QT=OFF -DENABLE_TESTS=OFF
+cmake --build "$BUILD" --target moderngekko-run moderngekko-launcher -j8
+
+ACTIVE_MODULE="$(cat "$TPL/build/modules/GMSE01/active-module.txt")"
+if [[ "$ACTIVE_MODULE" != /* ]]; then
+  ACTIVE_MODULE="$TPL/$ACTIVE_MODULE"
+fi
+if [[ ! -f "$ACTIVE_MODULE" ]]; then
+  echo "Generated GMSE01 desktop module not found: $ACTIVE_MODULE" >&2
+  exit 1
+fi
+
+APP_PARENT="$(dirname -- "$OUTPUT")"
+mkdir -p "$APP_PARENT"
+if [[ -e "$OUTPUT" ]]; then
+  mv "$OUTPUT" "$OUTPUT.previous.$(date +%Y%m%d-%H%M%S)"
+fi
+mkdir -p "$OUTPUT/Contents/MacOS" "$OUTPUT/Contents/Resources"
+cp "$ROOT/apple/macos/Info.plist" "$OUTPUT/Contents/Info.plist"
+cp "$ROOT/apple/macos/SunPad" "$OUTPUT/Contents/MacOS/SunPad"
+cp "$BUILD/SunPadFrontend" "$OUTPUT/Contents/MacOS/SunPadFrontend"
+cp "$BUILD/SunPadRunner" "$OUTPUT/Contents/MacOS/SunPadRunner"
+cp "$ACTIVE_MODULE" "$OUTPUT/Contents/MacOS/gGMSE01_recomp.dylib"
+cp -R "$BUILD/Sys" "$OUTPUT/Contents/MacOS/Sys"
+cp "$ROOT/apple/macos/default-config.ini" "$OUTPUT/Contents/Resources/default-config.ini"
+cp "$ROOT/apple/macos/default-GCPadNew.ini" "$OUTPUT/Contents/Resources/default-GCPadNew.ini"
+chmod +x "$OUTPUT/Contents/MacOS/SunPad"
+
+SOURCE_ICON="$ROOT/apple/ios/Assets.xcassets/AppIcon.appiconset/AppIcon.png"
+cp "$SOURCE_ICON" "$OUTPUT/Contents/Resources/AppIcon.png"
+
+codesign --force --deep --sign - "$OUTPUT"
+codesign --verify --deep --strict "$OUTPUT"
+echo "$OUTPUT"


### PR DESCRIPTION
## Summary
- add persisted Original 4:3, experimental 16:9, and experimental Fill Screen choices under Render Resolution without changing touch layout
- add a verified local Apple Silicon SunPad.app packaging path with Metal, resolution/fullscreen settings, keyboard defaults, and controller selection
- document iPhone performance debt, macOS setup, current verification, and game-data boundaries

## Validation
- changed Objective-C++ sources compiled successfully in the iOS Simulator build; the build stopped only at asset compilation because CoreSimulatorService was unavailable
- local arm64 macOS launcher, runner, and generated module built successfully
- SunPad.app passed ad-hoc codesign deep/strict verification and launched as a live GUI process
- Metal, 1920x1080, and Quartz keyboard defaults verified under Application Support
- bash/plist/patch/diff validation passed

Game data, saves, generated modules, and the local app bundle remain untracked.