### PR TITLE
Fix physical-device module upload path

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -92,3 +92,14 @@ the generated module into a development device container remains a local
 provisioning step; neither is bundled or tracked. This path has booted on a
 physical iPad, but it is not distribution packaging and physical-device audio
 is currently broken as documented in [AUDIO_ISSUE.md](AUDIO_ISSUE.md).
+
+Sign the generated module with the same Apple Development identity as the app,
+then copy it to the root of the app container's temporary directory:
+
+```sh
+codesign --force --sign <development-identity> --timestamp=none \
+  --identifier gGMSE01_recomp /tmp/module-ios-device/gGMSE01_recomp.dylib
+xcrun devicectl device copy to --device <device-udid> \
+  --domain-type appDataContainer --domain-identifier com.sunpad.SunPad \
+  --source /tmp/module-ios-device/gGMSE01_recomp.dylib --destination tmp
+```

--- a/scripts/ios-provision-device.sh
+++ b/scripts/ios-provision-device.sh
@@ -99,9 +99,10 @@ libtool -static -o "$LIBS_DIR/libSunPadCore.a" "${LIBS[@]}"
 echo "merged: $LIBS_DIR/libSunPadCore.a"
 
 # Dev provisioning manifest. DevModulePath is sandbox-relative: inside the app
-# sandbox /tmp maps to the app container's tmp/ directory, so the module is
-# injected at tmp/module-ios-device/ on the device. DevGameRoot is unused on a
-# real device (the import flow prefers the extracted root it produces).
+# sandbox /tmp maps to the app container's tmp/ directory. Keep the device
+# filename at the root of tmp because devicectl flattens directory uploads.
+# DevGameRoot is unused on a real device (the import flow prefers the extracted
+# root it produces).
 GAME_ROOT="$TPL/extracted/Super-Mario-Sunshine"
 MODULE="/tmp/module-ios-device/gGMSE01_recomp.dylib"
 cat > "$OUT/dev-config.plist" <<PLIST
@@ -114,7 +115,7 @@ cat > "$OUT/dev-config.plist" <<PLIST
 	<key>DevModulePath</key>
 	<string>$MODULE</string>
 	<key>DeviceModuleRelativePath</key>
-	<string>module-ios-device/gGMSE01_recomp.dylib</string>
+	<string>gGMSE01_recomp.dylib</string>
 </dict>
 </plist>
 PLIST


### PR DESCRIPTION
## Summary
- keep the generated device module at the root of the app container tmp directory, matching devicectl copy semantics
- document the required same-identity module signing and exact upload command

## Validation
- path is proven by the currently running iPhone build
- uploaded module read back byte-for-byte and passed strict codesign verification
- provisioning script passes bash syntax and diff checks