### PR TITLE
Publish first SunPad developer-preview IPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ game module.
 | Controllers | Touch and iOS GameController on mobile; keyboard or connected controller on macOS |
 | Settings | Live 1×–4× render scale, original 4:3 plus experimental widescreen/fill modes, and touch-layout settings |
 | Audio | Guest-timebase defect fixed; continuous desktop and Simulator audio verified; fresh physical-device audio acceptance remains |
-| Distribution | Source/development build only; no public IPA, TestFlight, or App Store release |
+| Distribution | Unsigned developer-preview IPA for user-side signing; no game image, saves, signing material, TestFlight, or App Store release |
 
 The mobile development build has been signed, installed, and played on a
 12.9-inch iPad Pro (6th generation). Physical-device boot, Metal rendering,
@@ -258,11 +258,12 @@ unrecompiled regions.
 
 ### Can I download an IPA?
 
-Not currently. This repository reproduces a **source/developer workflow**: the
-developer generates a game-specific module locally, signs the app and module,
-and provisions the module into the development app container. That is not a
-self-contained or publicly distributed IPA. No public IPA, TestFlight,
-AltStore, or App Store release has been announced.
+Yes. Download the unsigned **SunPad 0.1.0 Preview 1** IPA from
+[GitHub Releases](https://github.com/chrissotraidis/sunpad/releases), then
+re-sign it with your own Apple identity. It includes the required GMSE01
+ahead-of-time recompiled executable module, but no disc image, extracted game
+assets, save, settings, certificate, or provisioning profile. See
+[`docs/INSTALL_IPA.md`](docs/INSTALL_IPA.md).
 
 ### Do saves survive an app update?
 
@@ -286,6 +287,8 @@ packaging, and broader macOS gameplay acceptance remain explicit work.
 | [`scripts/prepare-game.sh`](scripts/prepare-game.sh) | Validate the supported local image and generate ignored game/module inputs |
 | [`scripts/ios-build-core.sh`](scripts/ios-build-core.sh) | Build and provision the Simulator core/module |
 | [`scripts/ios-build-core-device.sh`](scripts/ios-build-core-device.sh) | Build and provision the physical-device core/module |
+| [`scripts/package-ios.sh`](scripts/package-ios.sh) | Create the audited unsigned developer-preview IPA |
+| [`scripts/audit-ios-package.sh`](scripts/audit-ios-package.sh) | Reject game data, saves, signing material, and malformed IPA contents |
 | [`scripts/package-macos-app.sh`](scripts/package-macos-app.sh) | Build the local Apple Silicon `SunPad.app` bundle |
 | [`apple/ios/`](apple/ios/) | UIKit app shell, Files import, touch UI, and Apple adapter |
 | [`apple/macos/`](apple/macos/) | macOS bundle metadata, launcher wrapper, and keyboard defaults |
@@ -311,8 +314,9 @@ reference. See [`docs/RESEARCH.md`](docs/RESEARCH.md) and
 SunPad is an unofficial community project and is not affiliated with or
 endorsed by Nintendo. Super Mario Sunshine, Nintendo, and GameCube names and
 screenshots are used only to identify compatibility and demonstrate the
-project. No disc image, extracted Nintendo asset, generated game-derived
-module, or user save is included in the repository or a release. Each upstream
+project. No disc image, extracted Nintendo asset, or user save is included in
+the repository or a release. The developer-preview IPA includes the required
+ahead-of-time recompiled executable module. Each upstream
 component retains its own license and copyright. SunPad is licensed under
 GPL-3.0-or-later; see [`LICENSE`](LICENSE),
 [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md), and

--- a/SunPad.xcodeproj/project.pbxproj
+++ b/SunPad.xcodeproj/project.pbxproj
@@ -379,6 +379,14 @@
 					"-lcompression",
 					"-framework AVFAudio",
 				);
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-ffile-prefix-map=$(SRCROOT)=.",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(inherited)",
+					"-ffile-prefix-map=$(SRCROOT)=.",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.sunpad.SunPad;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -423,6 +431,14 @@
 					"-lresolv",
 					"-lcompression",
 					"-framework AVFAudio",
+				);
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-ffile-prefix-map=$(SRCROOT)=.",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(inherited)",
+					"-ffile-prefix-map=$(SRCROOT)=.",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.sunpad.SunPad;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,10 +1,10 @@
 # Maintainer Notes
 
-Last updated: 2026-08-09
+Last updated: 2026-08-10
 
 This is a public maintainer summary, not a machine-specific handoff. SunPad is
-an experimental source/developer workflow for `GMSE01` USA revision 0. It does
-not publish a ready-to-install IPA or any game data.
+an experimental developer preview for `GMSE01` USA revision 0. Its unsigned
+IPA requires user-side signing and a user-provided supported game image.
 
 ## Reproduce the local inputs
 
@@ -65,9 +65,8 @@ device data, and never use a removing CoreDevice container overlay for updates.
    rollback, removal-with-save-preservation, and diagnostic-sharing flows.
 5. Complete the exact HDMI + wired-controller replay and broader lifecycle,
    save/reload, performance, and extended-session checks.
-6. Define and audit any eventual binary/IPA distribution separately. Generated
-   game-derived modules, retail images, extracted files, saves, and signing
-   material must remain local.
+6. Continue auditing each binary release. Retail images, extracted assets,
+   saves, settings, and signing material must remain local.
 
 ## Reporting
 

--- a/docs/INSTALL_IPA.md
+++ b/docs/INSTALL_IPA.md
@@ -1,0 +1,16 @@
+# Install the developer-preview IPA
+
+SunPad 0.1.0 Preview 1 is an unsigned arm64 IPA for iPhone and iPad. It must
+be re-signed with your own Apple identity before installation.
+
+1. Download `SunPad-0.1.0-preview.1-unsigned.ipa` from the GitHub release.
+2. Verify its SHA-256 against the checksum on the release page.
+3. Re-sign the IPA with a sideloading workflow you trust, making sure the
+   nested `gGMSE01_recomp.dylib` is signed along with the app.
+4. Install it, open **••• → Game Data & Saves → Change or Reimport**, and
+   select your own legally obtained `GMSE01` USA revision 0 ISO/GCM image.
+
+The IPA contains the open-source SunPad/ModernGekko runtime and its required
+GMSE01 ahead-of-time recompiled executable module. It contains no disc image,
+extracted game assets, save, settings, certificate, or provisioning profile.
+It is not an App Store, TestFlight, or computer-free installation release.

--- a/docs/LEGAL_AND_PROVENANCE.md
+++ b/docs/LEGAL_AND_PROVENANCE.md
@@ -1,6 +1,6 @@
 # Legal and Provenance
 
-Last updated: 2026-08-09
+Last updated: 2026-08-10
 
 ## Project license
 
@@ -16,7 +16,7 @@ remain in force; the SunPad license does not replace them.
 SunPad will not:
 
 - Redistribute Super Mario Sunshine or any Nintendo copyrighted assets.
-- Commit disc images, extracted filesystems, textures, audio, or generated game-derived modules.
+- Commit disc images, extracted filesystems, textures, audio, or user saves.
 - Claim affiliation with or endorsement by Nintendo.
 - Misrepresent static recompilation as a complete clean-room rewrite if Dolphin-derived runtime services remain.
 
@@ -33,9 +33,11 @@ Users must provide their own legally obtained Super Mario Sunshine disc image. T
 
 See [DEPENDENCIES.md](DEPENDENCIES.md). Major runtime/recompiler components are
 GPL/Dolphin-derived and impose corresponding source, license, notice, and other
-obligations on distributed binaries that incorporate them. An eventual IPA or
-other binary release needs a separate artifact-level compliance audit; the
-current repository documents a local source/developer workflow only.
+obligations on distributed binaries that incorporate them. The
+developer-preview IPA includes the GMSE01 ahead-of-time recompiled executable
+module required to run the supported game, but no disc image, extracted assets,
+saves, settings, or signing material. The packaging audit enforces that
+boundary; users still provide their own supported image.
 
 ## Provenance of research claims
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Status
 
-Last updated: 2026-08-09
+Last updated: 2026-08-10
 
 Current phase: **SunPad now boots Super Mario Sunshine on a physical iPad as
 well as the iPhone and iPad simulators** as an ahead-of-time statically
@@ -86,6 +86,10 @@ code-generating loader).
     17 Pro Simulator at 640x528 EFB) and the current EFB resolution. Persistent
     logs redact current app-container and temporary-directory prefixes, and
     sharing requires a metadata disclosure confirmation before the share sheet.
+14. **Developer-preview packaging**: the Release app and required GMSE01
+    recompiled module package as a deterministic unsigned IPA. The audit checks
+    iPhoneOS/arm64 identity and rejects disc images, extracted game data, saves,
+    personal build paths, credentials, and signing material.
 
 ### Desktop (previously proven)
 

--- a/scripts/audit-ios-package.sh
+++ b/scripts/audit-ios-package.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+IPA="${1:?usage: scripts/audit-ios-package.sh <SunPad.ipa>}"
+[[ "$IPA" = /* ]] || IPA="$ROOT/$IPA"
+
+fail() {
+  echo "iOS package audit failed: $*" >&2
+  exit 1
+}
+
+[[ -f "$IPA" ]] || fail "IPA not found: $IPA"
+unzip -tq "$IPA" >/dev/null || fail "ZIP integrity check failed"
+
+entries="$(unzip -Z1 "$IPA")"
+grep -Fxq 'Payload/SunPad.app/SunPad' <<<"$entries" ||
+  fail "app executable is missing"
+grep -Fxq 'Payload/SunPad.app/gGMSE01_recomp.dylib' <<<"$entries" ||
+  fail "GMSE01 module is missing"
+grep -Fxq 'Payload/SunPad.app/LICENSE' <<<"$entries" ||
+  fail "GPL license is missing"
+grep -Fxq 'Payload/SunPad.app/THIRD_PARTY_NOTICES.md' <<<"$entries" ||
+  fail "third-party notices are missing"
+if grep -Eq '(^|/)\.\.(/|$)|^/|(^|/)__MACOSX(/|$)' <<<"$entries"; then
+  fail "archive contains an unsafe path"
+fi
+if grep -Eiq '\.(iso|gcm|rvz|wia|wbfs|gcz|gci|sav|raw|log|mobileprovision|p12|p8|pem|key|cer)$|(^|/)_CodeSignature(/|$)' <<<"$entries"; then
+  fail "archive contains game data, a save, a log, or signing material"
+fi
+
+extract_root="$(mktemp -d /tmp/sunpad-ipa-audit.XXXXXX)"
+trap 'rm -rf "$extract_root"' EXIT
+unzip -q "$IPA" -d "$extract_root"
+app="$extract_root/Payload/SunPad.app"
+executable="$app/SunPad"
+module="$app/gGMSE01_recomp.dylib"
+
+[[ "$(find "$extract_root/Payload" -mindepth 1 -maxdepth 1 -type d -name '*.app' | wc -l | tr -d ' ')" = 1 ]] ||
+  fail "IPA must contain exactly one app"
+[[ "$(lipo -archs "$executable")" = arm64 ]] || fail "app is not arm64-only"
+[[ "$(lipo -archs "$module")" = arm64 ]] || fail "module is not arm64-only"
+vtool -show-build "$executable" | grep -Eq 'platform +IOS$' || fail "app is not an iPhoneOS product"
+vtool -show-build "$module" | grep -Eq 'platform +IOS$' || fail "module is not an iPhoneOS product"
+[[ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$app/Info.plist")" = com.sunpad.SunPad ]] ||
+  fail "unexpected bundle identifier"
+[[ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$app/Info.plist")" = 0.1.0 ]] ||
+  fail "unexpected app version"
+[[ ! -d "$app/_CodeSignature" && ! -f "$app/embedded.mobileprovision" ]] ||
+  fail "unsigned package contains signing material"
+codesign --verify --strict "$app" >/dev/null 2>&1 && fail "app is still signed"
+codesign --verify --strict "$module" >/dev/null 2>&1 && fail "module is still signed"
+
+for file in "$executable" "$module" "$app/dev-config.plist"; do
+  [[ -e "$file" ]] || continue
+  if LC_ALL=C strings -a "$file" | grep -E '/Users/|/Volumes/|github_pat_|gh[pousr]_|AKIA[0-9A-Z]{16}' >/dev/null; then
+    fail "package contains a personal path or likely credential: $file"
+  fi
+done
+
+echo "iOS package audit passed: $IPA"

--- a/scripts/check-repository.sh
+++ b/scripts/check-repository.sh
@@ -18,6 +18,9 @@ plutil -lint apple/ios/Info.plist apple/macos/Info.plist
 ./tests/test-input-pipe-encoder.sh
 ./tests/test-diagnostics.sh
 
+test -x scripts/package-ios.sh
+test -x scripts/audit-ios-package.sh
+
 prohibited=$(git ls-files | grep -E '(^|/)(ref|DerivedData|Provisioned|build[^/]*)/|\.(iso|gcm|rvz|wia|wbfs|gcz|dylib|ipa|xcarchive|mobileprovision|p12|pem|key|gci|sav|raw)$' || true)
 if [[ -n "$prohibited" ]]; then
   echo "prohibited tracked material:" >&2

--- a/scripts/ios-build-core-device.sh
+++ b/scripts/ios-build-core-device.sh
@@ -30,6 +30,10 @@ CMAKE_COMMON=(
   -DENABLE_CUBEB=OFF -DENABLE_VULKAN=OFF
   -DUSE_SYSTEM_LZ4=OFF -DUSE_SYSTEM_ZSTD=OFF
   -DHAVE_PIPE2=0
+  "-DCMAKE_C_FLAGS=-ffile-prefix-map=$ROOT=."
+  "-DCMAKE_CXX_FLAGS=-ffile-prefix-map=$ROOT=."
+  "-DCMAKE_OBJC_FLAGS=-ffile-prefix-map=$ROOT=."
+  "-DCMAKE_OBJCXX_FLAGS=-ffile-prefix-map=$ROOT=."
   # cubeb's wrapper defaults USE_SANITIZERS=ON, which needs the
   # sanitizers-cmake submodule; sanitizers are pointless with cubeb off.
   -DUSE_SANITIZERS=OFF
@@ -43,15 +47,19 @@ ninja -C "$BUILD" libmoderngekko.a -j8
 
 echo "==> Building GMSE01 recompiled module for iOS device"
 ACTIVE_FILE="$TPL/build/modules-macos14/GMSE01/active-module.txt"
-if [[ ! -f "$ACTIVE_FILE" ]]; then
-  echo "prepared module manifest missing; run scripts/prepare-game.sh first" >&2
+if [[ -f "$ACTIVE_FILE" ]]; then
+  ACTIVE_MODULE="$(<"$ACTIVE_FILE")"
+  if [[ "$ACTIVE_MODULE" != /* ]]; then
+    ACTIVE_MODULE="$TPL/$ACTIVE_MODULE"
+  fi
+  GEN="$(dirname "$ACTIVE_MODULE")/dolrecomp-output/generated"
+else
+  GEN="$TPL/extracted/Super-Mario-Sunshine/recomp/generated"
+fi
+if [[ ! -f "$GEN/generated.c" || ! -f "$GEN/generated.h" ]]; then
+  echo "prepared module sources missing; run scripts/prepare-game.sh first" >&2
   exit 1
 fi
-ACTIVE_MODULE="$(<"$ACTIVE_FILE")"
-if [[ "$ACTIVE_MODULE" != /* ]]; then
-  ACTIVE_MODULE="$TPL/$ACTIVE_MODULE"
-fi
-GEN="$(dirname "$ACTIVE_MODULE")/dolrecomp-output/generated"
 if [[ ! -f "$GEN/main.dol" ]]; then
   cp "$TPL/extracted/Super-Mario-Sunshine/sys/main.dol" "$GEN/main.dol"
 fi

--- a/scripts/package-ios.sh
+++ b/scripts/package-ios.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+APP="${1:-/tmp/SunPadReleaseData/Build/Products/Release-iphoneos/SunPad.app}"
+MODULE="${2:-/tmp/sunpad-module-ios-device/gGMSE01_recomp.dylib}"
+OUTPUT="${3:-$ROOT/artifacts/SunPad-0.1.0-preview.1-unsigned.ipa}"
+
+[[ "$APP" = /* ]] || APP="$ROOT/$APP"
+[[ "$MODULE" = /* ]] || MODULE="$ROOT/$MODULE"
+[[ "$OUTPUT" = /* ]] || OUTPUT="$ROOT/$OUTPUT"
+[[ -d "$APP" ]] || { echo "app not found: $APP" >&2; exit 1; }
+[[ -f "$MODULE" ]] || { echo "module not found: $MODULE" >&2; exit 1; }
+
+package_root="$(mktemp -d /tmp/sunpad-package.XXXXXX)"
+trap 'rm -rf "$package_root"' EXIT
+staged_app="$package_root/Payload/SunPad.app"
+mkdir -p "$(dirname "$staged_app")" "$(dirname "$OUTPUT")"
+ditto "$APP" "$staged_app"
+ditto "$MODULE" "$staged_app/gGMSE01_recomp.dylib"
+
+rm -rf "$staged_app/_CodeSignature"
+rm -f "$staged_app/embedded.mobileprovision"
+codesign --remove-signature "$staged_app/gGMSE01_recomp.dylib" 2>/dev/null || true
+codesign --remove-signature "$staged_app" 2>/dev/null || true
+
+# Keep only the device-relative module name; local host paths never belong in
+# a public package.
+if [[ -f "$staged_app/dev-config.plist" ]]; then
+  /usr/libexec/PlistBuddy -c 'Delete :DevGameRoot' "$staged_app/dev-config.plist" 2>/dev/null || true
+  /usr/libexec/PlistBuddy -c 'Delete :DevModulePath' "$staged_app/dev-config.plist" 2>/dev/null || true
+fi
+cp "$ROOT/LICENSE" "$staged_app/LICENSE"
+cp "$ROOT/THIRD_PARTY_NOTICES.md" "$staged_app/THIRD_PARTY_NOTICES.md"
+cp "$ROOT/docs/INSTALL_IPA.md" "$staged_app/INSTALL_IPA.md"
+
+find "$package_root" -exec touch -h -t 200001010000 {} +
+temporary_ipa="$package_root/SunPad.ipa"
+(
+  cd "$package_root"
+  find Payload \( -type f -o -type l \) -print | LC_ALL=C sort |
+    zip -X -q -y "$temporary_ipa" -@
+)
+mv -f "$temporary_ipa" "$OUTPUT"
+
+"$ROOT/scripts/audit-ios-package.sh" "$OUTPUT"
+echo "IPA: $OUTPUT"
+shasum -a 256 "$OUTPUT"
+echo "This unsigned IPA must be re-signed before installation."


### PR DESCRIPTION
## Summary
- add deterministic unsigned IPA packaging and strict content audit
- bundle the required GMSE01 recompiled module without disc images, saves, settings, credentials, or signing material
- document user-side signing and update public release status

## Validation
- Release iPhoneOS build succeeded
- two IPA packaging runs were byte-identical
- SHA-256: 4fdfe130eb3669dc3d7f5e3e5925041378905cacb11ac708dafc080cb40a8ebb
- ./scripts/check-repository.sh passed

## Boundary
The IPA is unsigned and requires user-side signing plus a user-provided GMSE01 USA revision 0 image.