### PR TITLE
Fix iPhone touch layout default

### DIFF
--- a/apple/ios/SunPadGameOverlay.mm
+++ b/apple/ios/SunPadGameOverlay.mm
@@ -847,8 +847,10 @@ static CGFloat SunPadDefaultSizeScaleForControl(UIView *view, NSString *identifi
     SunPadGameButton *b = [self buttonWithMask:SunPadButtonB];
     SunPadGameButton *x = [self buttonWithMask:SunPadButtonX];
     SunPadGameButton *y = [self buttonWithMask:SunPadButtonY];
-    CGRect aDefault = phone ?
-        SunPadFrameAtNormalizedCenter(safe, 0.8916544656, 0.7409513961, large, large) : pad ?
+    // A was not present in the captured iPhone preferences because it was not
+    // moved. Keep the original phone fallback so the sparse captured layout
+    // reconstructs the exact arrangement the user made.
+    CGRect aDefault = pad ?
         SunPadFrameAtNormalizedCenter(safe, 0.8916544656, 0.7409513961, large, large) :
         CGRectMake(CGRectGetMaxX(safe) - margin - large,
                    CGRectGetMaxY(safe) - margin - camera - large - 18.0 * scale,

--- a/tests/test-iphone-touch-layout-defaults.sh
+++ b/tests/test-iphone-touch-layout-defaults.sh
@@ -10,6 +10,11 @@ grep -Fq '0.9233055556, 0.8130067568' "$overlay"
 grep -Fq '0.0812777778, 0.4677364865' "$overlay"
 grep -Fq '1.158457040786743' "$overlay"
 grep -Fq 'savedScales[identifier] != nil' "$overlay"
+if grep -Fq 'CGRect aDefault = phone ?' "$overlay"; then
+  echo "iPhone A must retain the original fallback because it was absent from the sparse capture" >&2
+  exit 1
+fi
+grep -Fq 'CGRectGetMaxX(safe) - margin - large' "$overlay"
 grep -Fq '0.1310395315, 0.7905894519' "$overlay"
 grep -Fq '0.2686676428, 0.7947259566' "$overlay"
 


### PR DESCRIPTION
Corrects the iPhone default to match the accepted physical iPhone layout. The captured preferences were sparse because A was never moved; this keeps A on its original phone fallback while preserving every captured moved-control position and B-button size. iPad defaults are unchanged.\n\nValidated with the focused layout regression, full repository gate, signed physical-device build, in-place install, and live process launch.