### PR TITLE
Fix macOS static recomp fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@
 SunPad packages a native Apple ARM64 app around a
 [DolRecomp](https://github.com/encounter/dolrecomp)-generated Super Mario
 Sunshine module and the ModernGekko/Dolphin-derived compatibility runtime.
-The original PowerPC code runs as ahead-of-time recompiled host code, without
-a runtime PowerPC JIT, while Dolphin's Metal backend renders into the iOS app.
+Covered PowerPC game-code regions run as ahead-of-time recompiled host code.
+iPhone and iPad use interpreter fallback with no runtime PowerPC JIT; Apple
+Silicon Mac uses JitArm64 only for code outside the recompiled module.
+Dolphin's Metal backend renders into the Apple apps.
 
 The mobile app imports a user-provided supported GameCube image through Files,
 extracts it on-device, and provides a landscape touch controller alongside
@@ -285,6 +287,13 @@ it is not a general-purpose loader for other GameCube games.
 No runtime PowerPC JIT is used. The supported game's PowerPC code is
 ahead-of-time recompiled for ARM64, with the runtime interpreter handling
 unrecompiled regions.
+
+### Does it use a JIT on Apple Silicon Mac?
+
+Only as a fallback. The ahead-of-time module executes covered game code, and
+JitArm64 handles code outside that module before yielding back to it. This
+ARM64 handoff includes the fix from
+[ExpansionPak/RecompCore PR #6](https://github.com/ExpansionPak/RecompCore/pull/6).
 
 ### Can I download an IPA?
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,9 +43,11 @@ sunpad/
 - Preferred: AOT statically recompiled guest code module (DolRecomp C →
   host-native module).
 - Allowed: Dolphin-derived compatibility services for hardware/OS.
-- Forbidden on Apple platforms: runtime PowerPC JIT. On iOS the static-recomp
-  fallback uses the interpreter, and the generic software vertex loader
-  replaces Dolphin's ARM64 code-generating loader.
+- macOS: JitArm64 may execute uncovered fallback code, but its dispatcher must
+  yield back whenever the AOT module covers the next address.
+- iOS/iPadOS: runtime PowerPC JIT is forbidden. Static-recomp fallback uses the
+  interpreter, and the generic software vertex loader replaces Dolphin's ARM64
+  code-generating loader.
 
 ## iOS host layering
 

--- a/docs/AUDIO_ISSUE.md
+++ b/docs/AUDIO_ISSUE.md
@@ -46,16 +46,21 @@ Producer-side captures via Dolphin's `[DSP] DumpAudio` (`dspdump.wav`,
 | Desktop, parity mode, unfixed, CPU throttled to ~7% real-time (E-cores) | module-dominant | producer stream still complete in virtual time — slowness alone does not silence the producer |
 | **iOS Simulator app, fixed core** (no JIT, full iOS audio stack) | module-dominant | **continuous audio, 92.8% loud over 139 s, boot → title → attract** |
 
-## Why desktop never showed this
+## Why desktop did not show this before the ARM64 handoff repair
 
-The fallback JIT's yield hook (`StaticRecompShouldYieldAt`) is only wired
-into the **Jit64 (x86)** dispatcher. On Apple Silicon, JitArm64 never yields
-back to the module, so every previous desktop "static recomp" run silently
-executed almost entirely in Dolphin's JIT — with the JIT's correct timebase.
-Only iOS (which builds no JIT) actually ran the module, which is why the
-symptom looked iOS-only. `STATICRECOMP_NO_FALLBACK_JIT=1` now exposes the
-honest module + interpreter contract on desktop. Wiring the yield hook into
-JitArm64 is separate follow-up work.
+The fallback JIT's yield hook (`StaticRecompShouldYieldAt`) was wired only
+into the **Jit64 (x86)** dispatcher. On Apple Silicon, JitArm64 did not yield
+back to the module, so earlier desktop "static recomp" runs silently executed
+almost entirely in Dolphin's JIT — with the JIT's correct timebase. Only iOS
+(which builds no JIT) actually ran the module, which is why the symptom looked
+iOS-only. `STATICRECOMP_NO_FALLBACK_JIT=1` exposed the honest module plus
+interpreter contract on desktop.
+
+This historical gap was repaired on 2026-08-13 by carrying the two-file fix
+from ExpansionPak/RecompCore PR #6. JitArm64 now disables fallback block
+linking, asks StaticRecomp whether the next address is covered, stores the live
+guest PC, and yields back to the AOT module. The no-JIT environment switch
+remains available for iOS-parity investigation.
 
 ## Reassessment of the 2026-08-06/07 device evidence
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,6 +1,6 @@
 # Known Issues
 
-Last updated: 2026-08-11
+Last updated: 2026-08-13
 
 ## iOS / iPadOS
 
@@ -129,13 +129,6 @@ Last updated: 2026-08-11
 
 ## Desktop Stage 1 gaps
 
-0. **Fallback JIT hogs execution on Apple Silicon** — the JIT-to-module
-   yield hook (`StaticRecompShouldYieldAt`) is only wired into the Jit64
-   (x86) dispatcher, so on arm64 desktops the fallback JitArm64 takes over
-   at the first non-module address and never returns; prior desktop
-   "static recomp" evidence mostly exercised Dolphin's JIT. Run with
-   `STATICRECOMP_NO_FALLBACK_JIT=1` for the true module + interpreter
-   contract (matches iOS). Wiring the yield hook into JitArm64 is open work.
 1. **Input path not fully proven** — pipe input advances menus, but the
    file-select cursor interaction was worked around rather than cleanly
    understood; interactive plaza/objective/save gates remain open.
@@ -145,6 +138,11 @@ Last updated: 2026-08-11
 
 ## Resolved / non-blocking observations
 
+- **ARM64 fallback handoff repaired (2026-08-13)** — the two-file fix from
+  ExpansionPak/RecompCore PR #6 disables fallback block linking, checks
+  `StaticRecompShouldYieldAt` in the JitArm64 dispatcher, and stores the guest
+  PC before returning to the AOT module. Focused headless and Metal runs reached
+  more than 191 million native dispatches instead of the old 682 signature.
 - ModernGekko first configure needed dolphin Externals initialized.
 - Module C compile at `-O2` takes ~15-25 minutes (desktop and simulator).
 - Early "exit immediately" desktop launches were process-termination

--- a/docs/MACOS.md
+++ b/docs/MACOS.md
@@ -1,6 +1,6 @@
 # macOS
 
-Last updated: 2026-08-09
+Last updated: 2026-08-13
 
 ## Current status
 
@@ -13,6 +13,12 @@ The 2026-08-08 package was built, ad-hoc signed, verified with `codesign`, and
 launched as a live GUI process. This proves the app shell and setup path; plaza
 gameplay, objective completion, save/reload, and extended-session acceptance
 remain open desktop gates.
+
+The ARM64 fallback contract now disables block linking while JitArm64 is a
+StaticRecomp fallback and returns to the AOT module when the next address is
+covered. A focused Metal smoke run increased native dispatches from the broken
+682-dispatch signature to 193,808,714 before a clean shutdown. This is runtime
+path evidence, not full hands-on gameplay acceptance.
 
 ## Build and run
 
@@ -49,7 +55,7 @@ profiles live under `~/Library/Application Support/SunPad`.
 
 ## Current properties
 
-- ARM64 process, no Rosetta, no PowerPC JIT product path
+- ARM64 process, no Rosetta; AOT module with JitArm64 fallback for uncovered code
 - Metal-preferred rendering through the compatibility runtime where available
 - Connected controller + keyboard
 - Memory-card save persistence
@@ -60,3 +66,13 @@ profiles live under `~/Library/Application Support/SunPad`.
 ## Remaining gate criteria
 
 See the Stage 2 checklist in the project goal / [STATUS.md](STATUS.md).
+
+## Upstream fix and rollback
+
+SunPad keeps its reviewed RecompCore pin and carries the two-file fix from
+[ExpansionPak/RecompCore PR #6](https://github.com/ExpansionPak/RecompCore/pull/6)
+inside the complete Dolphin-runtime patch snapshot. Reverting those two hunks
+restores the previous behavior for diagnosis, where JitArm64 takes over after
+the first fallback and native dispatches remain near 682. The existing
+`STATICRECOMP_NO_FALLBACK_JIT=1` developer mode bypasses JitArm64 and retains
+the module-plus-interpreter parity path used for iOS investigation.

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -84,7 +84,7 @@ Conclusion for SunPad planning:
 | Generated host code | Local DolRecomp output derived from a user disc; not redistributed |
 | Compatibility runtime / HLE services | Host replacements for GameCube hardware/OS services (GX, audio, disc, PAD, etc.) |
 | Emulation-derived runtime | Dolphin-lineage components still providing hardware/OS behavior |
-| JIT | Runtime translation of guest code; **forbidden** as the product CPU path on Apple targets |
+| JIT | Runtime translation of guest code; forbidden on iOS/iPadOS, and allowed only as fallback outside covered AOT regions on macOS |
 
 ## Selected Stage 1 path
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Status
 
-Last updated: 2026-08-11
+Last updated: 2026-08-13
 
 Current phase: **SunPad now boots Super Mario Sunshine on a physical iPad as
 well as the iPhone and iPad simulators** as an ahead-of-time statically
@@ -22,10 +22,10 @@ iOS Simulator; fresh physical-device audio re-acceptance remains open.
 
 Ahead-of-time statically recompiled game CPU code running through a
 Dolphin-derived GameCube compatibility runtime (ModernGekko / RecompCore
-lineage). Not a matching decompilation, not a pure high-level rewrite, and on
-Apple platforms no runtime PowerPC JIT (the static-recomp fallback uses the
-interpreter, and the generic vertex loader replaces Dolphin's ARM64
-code-generating loader).
+lineage). Not a matching decompilation or a pure high-level rewrite. macOS uses
+JitArm64 for uncovered fallback code and returns to the AOT module at covered
+addresses. iOS/iPadOS use interpreter fallback with no runtime PowerPC JIT, and
+the generic vertex loader replaces Dolphin's ARM64 code-generating loader.
 
 ## Stage gates
 
@@ -109,6 +109,9 @@ code-generating loader).
    defaults to Metal, exposes resolution/fullscreen settings, seeds WASD +
    keyboard controls, and allows a connected controller profile to replace
    them. The app bundle passes ad-hoc signing verification and launches.
+6. The repaired ARM64 fallback contract kept the AOT module active in focused
+   headless and Metal smoke runs: the prior 682 native dispatches increased to
+   more than 191 million before clean shutdown.
 
 ## What does not work / not yet proven
 
@@ -117,9 +120,6 @@ code-generating loader).
   Simulator app only. Note the surviving device DSP dump from 2026-08-06 was
   already continuous at music level, so any residual audible defect on
   device should be debugged in the iOS output/consumer chain.
-- Desktop caveat: on Apple Silicon the fallback JIT never yields back to the
-  recompiled module (yield hook is Jit64-only), so desktop static-recomp
-  evidence requires `STATICRECOMP_NO_FALLBACK_JIT=1`.
 - The recompiled module is provisioned from the Mac toolchain (iOS has no C
   compiler); import/extract/boot works on-device, but provisioning a module
   for a disc other than the dev-provisioned GMSE01 build is not implemented.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -245,10 +245,9 @@ a PID, or a clean log alone does not satisfy hands-on input or gameplay rows.
 
 All rows use Dolphin's producer-side `[DSP] DumpAudio` capture
 (`dspdump.wav`, 32,028 Hz) analyzed as 250 ms RMS windows; "loud" =
-RMS > 40. Desktop rows run `moderngekko-run` in iOS-parity mode
-(`STATICRECOMP_NO_FALLBACK_JIT=1`), which is required on Apple Silicon
-because the fallback JIT otherwise takes over execution (yield hook is
-Jit64-only).
+RMS > 40. The 2026-08-08 desktop rows used `moderngekko-run` in iOS-parity
+mode (`STATICRECOMP_NO_FALLBACK_JIT=1`) because the then-unfixed fallback JIT
+took over execution. The ARM64 handoff was repaired on 2026-08-13.
 
 | Check | Result | Evidence |
 |---|---|---|
@@ -257,6 +256,16 @@ Jit64-only).
 | Desktop parity, unfixed, ~7% speed (E-cores) | Producer complete in virtual time | 20.7 s virtual captured over 300 s wall, content matches full-speed run |
 | iOS Simulator app, fixed core | **Pass** | 92.8% loud over 139 s, boot → title → attract; iPhone 17 Pro sim |
 | Physical iPad re-acceptance | **Open** | requires `scripts/ios-build-core-device.sh` rebuild + on-device run |
+
+## ARM64 static-recomp fallback repair (2026-08-13)
+
+The exact two-file backport of ExpansionPak/RecompCore PR #6 was compiled and
+linked against SunPad's pinned, patched Release runtime. Ten-second headless
+runs changed the shutdown signature from `native=682` to `native=191555041`;
+the no-JIT parity control recorded `native=192451095 fallback=128616`. A short
+Metal run loaded the GMSE01 module and shut down cleanly with
+`native=193808714`. These are execution-path smoke tests; plaza, objective,
+save/reload, controller, and extended-session acceptance remain open.
 
 ## Stage 1 desktop checklist
 

--- a/patches/ModernGekko-dolphin/0001-sunpad-ios-runtime.patch
+++ b/patches/ModernGekko-dolphin/0001-sunpad-ios-runtime.patch
@@ -1,5 +1,5 @@
 From: SunPad contributors
-Subject: [PATCH] Add the complete SunPad iOS runtime integration
+Subject: [PATCH] Add the complete SunPad Apple runtime integration
 
 This snapshot captures every reviewed local Dolphin change required by SunPad.
 
@@ -980,4 +980,111 @@ index 0000000000..e87afbdc91
 +  return 0.0;
 +}
 +}  // namespace GCAdapter
-
+diff --git a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Cache.cpp b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Cache.cpp
+index b59915ab1b..83c21ce0ea 100644
+--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Cache.cpp
++++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Cache.cpp
+@@ -3,6 +3,8 @@
+ 
+ #include "Core/PowerPC/JitArm64/Jit.h"
+ 
++#include <cstdlib>
++
+ #include <cstdio>
+ #include <optional>
+ #include <span>
+@@ -79,9 +81,32 @@ void JitArm64::Init()
+   GenerateAsmAndResetFreeMemoryRanges();
+ }
+ 
++
++// On by default, matching x86-64 where StaticRecomp is already the default CPU
++// core. Set MODERNGEKKO_ARM64_STATICRECOMP=0 to run Dolphin's JitArm64 instead.
++// Shared with JitAsm.cpp: both the block-linking policy and the dispatcher hook
++// must agree, and reading the variable in each translation unit separately
++// would let them disagree if one were ever changed alone.
++bool JitArm64StaticRecompEnabled()
++{
++  static const bool enabled = [] {
++    const char* v = std::getenv("MODERNGEKKO_ARM64_STATICRECOMP");
++    return !v || !*v || *v != '0';
++  }();
++  return enabled;
++}
++
+ void JitArm64::SetBlockLinkingEnabled(bool enabled)
+ {
+-  jo.enableBlocklink = enabled && !SConfig::GetInstance().bJITNoBlockLinking;
++  // As the StaticRecomp fallback, blocks must not link to each other. Linked
++  // blocks chain without returning to the dispatcher, so control would never
++  // get back to StaticRecompCore to check whether the recompiled module covers
++  // the next address -- which is exactly why the module was entered once at
++  // boot and never again on arm64. Jit64 has always done this; JitArm64 did
++  // not, which made the whole static recompilation inert on Apple Silicon.
++  jo.enableBlocklink =
++      enabled && !SConfig::GetInstance().bJITNoBlockLinking &&
++      !(IsStaticRecompFallback() && JitArm64StaticRecompEnabled());
+ }
+ 
+ void JitArm64::SetOptimizationEnabled(bool enabled)
+diff --git a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+index a65fd33a8f..c8def7a124 100644
+--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
++++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+@@ -2,6 +2,9 @@
+ // SPDX-License-Identifier: GPL-2.0-or-later
+ 
+ #include "Core/PowerPC/JitArm64/Jit.h"
++#include "Core/PowerPC/StaticRecomp/StaticRecompCore.h"
++
++#include <cstdlib>
+ 
+ #include <bit>
+ #include <limits>
+@@ -28,6 +31,11 @@
+ 
+ using namespace Arm64Gen;
+ 
++
++// Defined in JitArm64_Cache.cpp. The block-linking policy there and the
++// dispatcher hook below must make the same decision, so they share one reader.
++bool JitArm64StaticRecompEnabled();
++
+ void JitArm64::GenerateAsm()
+ {
+   const Common::ScopedJITPageWriteAndNoExecute enable_jit_page_writes;
+@@ -96,6 +104,25 @@ void JitArm64::GenerateAsm()
+ 
+   dispatcher_no_check = GetCodePtr();
+ 
++  // Ask StaticRecompCore whether the recompiled module wants this address
++  // before falling into the JIT's own block lookup. A non-zero answer leaves
++  // the dispatcher so the module can run it. DISPATCHER_PC (W26) and PPC_REG
++  // (X29) are callee-saved under AAPCS64, so they survive the call.
++  FixupBranch static_recomp_exit;
++  const bool static_recomp_yield = IsStaticRecompFallback() && JitArm64StaticRecompEnabled();
++  if (static_recomp_yield)
++  {
++    ABI_CallFunction(&StaticRecompShouldYieldAt, DISPATCHER_PC);
++    // Write the PC back before we can leave. JitArm64 keeps the PC in
++    // DISPATCHER_PC (W26) and only spills it to PPCSTATE at do_timing, which
++    // this exit path bypasses -- so StaticRecompCore was resuming from a stale
++    // ppcState.pc and dispatching the module at the wrong address. Jit64's
++    // identical hook is safe only because x86 keeps the PC in memory
++    // throughout. This is the one place the two JITs are not interchangeable.
++    STR(IndexType::Unsigned, DISPATCHER_PC, PPC_REG, PPCSTATE_OFF(pc));
++    static_recomp_exit = CBNZ(ARM64Reg::W0);
++  }
++
+   bool assembly_dispatcher = true;
+ 
+   if (assembly_dispatcher)
+@@ -225,6 +252,8 @@ void JitArm64::GenerateAsm()
+ 
+   dispatcher_exit = GetCodePtr();
+   SetJumpTarget(exit);
++  if (static_recomp_yield)
++    SetJumpTarget(static_recomp_exit);
+ 
+   // Reset the stack pointer, since the BLR optimization may have pushed things onto the stack
+   // without popping them.

--- a/patches/README.md
+++ b/patches/README.md
@@ -6,7 +6,7 @@ its ignored upstream trees:
 | Patch | Applies to | Contents |
 |---|---|---|
 | `ModernGekko/0001-sunpad-apple-runtime.patch` | Pinned ModernGekko root | Apple frontend/runtime integration, macOS Metal defaults, iOS platform and build wiring, and the SunPad-owned files required by the Apple workflows |
-| `ModernGekko-dolphin/0001-sunpad-ios-runtime.patch` | Pinned `ModernGekko/vendor/dolphin` | Complete Dolphin-derived iOS/runtime delta, including Metal/platform guards and stubs, no-JIT/software-loader behavior, iOS audio integration, StaticRecomp timebase/TL/TU fixes, and iOS backend/link fixes |
+| `ModernGekko-dolphin/0001-sunpad-ios-runtime.patch` | Pinned `ModernGekko/vendor/dolphin` | Complete Dolphin-derived Apple/runtime delta, including Metal/platform guards and stubs, iOS no-JIT/software-loader behavior, audio integration, StaticRecomp timebase/TL/TU fixes, and the macOS ARM64 fallback contract |
 
 These replace the earlier partial patch series. Required CoreAudio,
 mixer, platform-stub, frontend, and build changes are no longer
@@ -24,6 +24,14 @@ The bootstrap script checks out the exact revisions recorded in
 revision, and applies each patch once. It accepts a patch that is already
 fully applied and stops if a checkout is on an unexpected commit or either
 snapshot does not apply cleanly.
+
+The ARM64 fallback-contract hunks are the focused fix from
+[ExpansionPak/RecompCore PR #6](https://github.com/ExpansionPak/RecompCore/pull/6),
+authored by Douglas Whittingham. They disable block linking while JitArm64 is a
+StaticRecomp fallback and return to the AOT module at covered addresses. To
+roll back only this behavior, revert those hunks in the snapshot and recreate
+the pinned dependency tree; the expected old diagnostic signature is roughly
+682 native dispatches before JitArm64 takes over.
 
 The snapshots contain generic Apple/runtime integration for SunPad's current
 `GMSE01` development path. A future game-specific address map, runtime


### PR DESCRIPTION
## Why

On Apple Silicon, JitArm64 could take over at the first address outside the generated module and never yield back. That made earlier macOS static-recomp runs execute almost entirely through Dolphin's fallback JIT even though the AOT module loaded.

## How

- Carry the exact two-file fallback-contract repair from [ExpansionPak/RecompCore PR 6](https://github.com/ExpansionPak/RecompCore/pull/6) inside SunPad's existing complete Dolphin patch snapshot.
- Disable JitArm64 block linking while it acts as the StaticRecomp fallback.
- Ask StaticRecompShouldYieldAt before JIT dispatch, store the live guest PC, and return to the AOT module at covered addresses.
- Keep the reviewed RecompCore pin unchanged and keep iOS/iPadOS on interpreter fallback with no runtime PowerPC JIT.
- Update architecture, status, testing, and rollback documentation to state the macOS/iOS distinction precisely.

## Validation

- Clean dependency bootstrap and patch replay succeeded.
- ./scripts/check-repository.sh passed.
- Clean Apple Silicon Release runtime compiled both repaired JitArm64 files.
- macOS package completed, targeted macOS 14, and passed codesign --verify --deep --strict.
- Packaged Null smoke: native=202382114, fallback=0, clean shutdown.
- Packaged Metal smoke: native=203815254, fallback=0, clean shutdown.
- No extracted game data, generated module, or build output is tracked.

These are execution-path smoke tests, not full hands-on gameplay acceptance.

## Rollback

Revert this PR to remove the two JitArm64 hunks and their documentation. The dependency pin remains unchanged, so rollback is a single repository revert followed by recreating the pinned dependency tree. The old diagnostic signature is approximately 682 native dispatches before JitArm64 takes over. STATICRECOMP_NO_FALLBACK_JIT=1 remains available as the module-plus-interpreter parity control.