### PR TITLE
Record Issue 12 retest and clean iOS startup noise

### DIFF
--- a/docs/IOS_IPADOS.md
+++ b/docs/IOS_IPADOS.md
@@ -1,6 +1,6 @@
 # iOS and iPadOS
 
-Last updated: 2026-08-11
+Last updated: 2026-09-01
 
 ## Current status
 
@@ -170,10 +170,13 @@ controller mapping and physical Bluetooth, wired, and natural-sleep reconnect
 remain open. The installed iOS 26.5 Simulator image does not
 expose a VoiceOver setting:
 
-1. **Evidence intake first.** The reported iPhone 15 Pro slowdown is blocked on
-   the offered SunPad log plus scene, render scale, controller, thermal state,
-   and elapsed-time details. The LiveContainer failure is blocked on the
-   checklist in [INSTALL_IPA.md](INSTALL_IPA.md). Do not guess at either cause.
+1. **Evidence intake first.** The iPhone 15 Pro reporter's short Preview 6 log
+   is significantly healthier at the supported 30 FPS / Original 4:3 / 1x
+   baseline, but it contains no scene or longer-route evidence. If sustained
+   slowdown returns, collect **Report a Problem…** after the event with the
+   scene and approximate play time. The LiveContainer failure is blocked on
+   the checklist in [INSTALL_IPA.md](INSTALL_IPA.md). Do not guess at either
+   cause.
 2. **Loading polish only.** Improve the existing presentation while keeping the
    current startup architecture and first-frame completion signal.
 3. **Touch controls.** Grouped D-pad editing and the wider analog R slider are

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,6 +1,6 @@
 # Known Issues
 
-Last updated: 2026-08-31
+Last updated: 2026-09-01
 
 ## iOS / iPadOS
 
@@ -65,11 +65,15 @@ Last updated: 2026-08-31
     data. Provision the module before user data and use a non-removing
     directory overlay. Back up and read back each device's saves and settings;
     never treat an app-install success message as preservation proof.
-13. **iPhone slowdown report needs its log** — an iPhone 15 Pro tester reports
-    slowdown after several minutes and has offered a diagnostic log. Until the
-    log, exact scene, render scale, controller connection, thermal state, and
-    elapsed time are captured, this remains an undiagnosed report rather than
-    evidence for a particular runtime fix.
+13. **iPhone slowdown remains open after an improved Preview 6 retest** — the
+    iPhone 15 Pro reporter described Preview 6 as significantly more stable.
+    Its approximately 80-second build-4 log used supported 30 FPS, Original
+    4:3, and 1x at nominal thermals and held full speed in five of six samples;
+    one brief 20.4 FPS / 0.969-speed sample recovered immediately. Because the
+    report did not include the scene, frequency, screenshot, or a longer route,
+    it does not close the original several-minute slowdown. If sustained
+    slowdown returns, capture **Report a Problem…** after it happens and include
+    the scene and approximate play time.
 14. **LiveContainer is unverified** — one user reports that the Preview 1 IPA
     does not work in LiveContainer. SunPad's supported preview path re-signs
     both the app and nested `gGMSE01_recomp.dylib` and installs normally. A

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Status
 
-Last updated: 2026-08-13
+Last updated: 2026-09-01
 
 Current phase: **SunPad now boots Super Mario Sunshine on a physical iPad as
 well as the iPhone and iPad simulators** as an ahead-of-time statically
@@ -133,7 +133,10 @@ the generic vertex loader replaces Dolphin's ARM64 code-generating loader.
 - iPhone 14 boot is proven but performance is below the iPad experience even
   at 1×; iPhone 15 Pro or newer is recommended for iPhone development testing.
 - A community iPhone 15 Pro report describes slowdown after several minutes,
-  and physical-iPhone 14 testing reproduced the single-core ceiling. A
+  and physical-iPhone 14 testing reproduced the single-core ceiling. A short
+  Preview 6 follow-up on that iPhone 15 Pro was significantly more stable at
+  the supported 30 FPS / Original 4:3 / 1x baseline, with one brief recovered
+  dip, but no scene-matched long-session acceptance. A
   default-off **Reduced CPU Clock 90% (Unstable, Restart Required)** exposes
   the synchronized 90%-clock, `userInitiated` profile for wider evidence
   collection. Two confirmed-gameplay iPhone 14 traces showed CPU headroom at

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -1,6 +1,7 @@
 # Performance and stability technical debt
 
 - **Assessment date:** 2026-08-12
+- **Evidence updated through:** 2026-09-01 (Preview 6 Issue #12 follow-up)
 - **SunPad source assessed:** `54a5f78965b9075bb25427492a266eaad756f64c`
 - **Scope:** GMSE01 USA revision 0, Apple ARM64, original 30 FPS and the
   default-off experimental 60 FPS mode
@@ -140,8 +141,16 @@ must be measured rather than dismissed.
 - Whether higher render scales materially worsen each reported slowdown. The
   iPhone 14 reproduction proves that native 1x does not eliminate the issue,
   but a matched per-scene scale matrix is still needed.
-- The reported iPhone 15 Pro slowdown. Its supplied Preview 1 logs predate
-  performance sampling and cannot identify the subsystem or Game Mode state.
+- Issue #12 remains open on the iPhone 15 Pro. A September 1 Preview 6 report
+  (`SP-133DE3C9`) confirms that the one-time migration disabled the old 90%
+  experiment and selected original 30 FPS, Original 4:3, and 1x at nominal
+  thermals. Five of six ten-second snapshots reported 29.9-30.0 FPS at
+  0.998-1.012 speed; one approximately one-second performance window fell to
+  20.4 FPS / 0.969 speed and recovered by the next snapshot. The reporter
+  described the build as significantly more stable, but the runtime covered
+  only about 80 seconds and supplied no scene, frequency, or screenshot. This
+  is improved short-run evidence, not a resolved long-session result or a
+  subsystem attribution.
 
 ## Important non-solutions
 
@@ -172,6 +181,10 @@ must be measured rather than dismissed.
 - Do not tune the audio queue first for a general frame slowdown. Audio can
   reveal lost real-time speed, but the known guest-timebase producer bug is
   already fixed and buffering changes can hide rather than remove CPU stalls.
+- Do not treat removal of the iOS `Failed to allocate memory space: 0x3`
+  startup message as a performance fix. StaticRecomp's empty block cache never
+  stores JIT blocks; disabling its unused 64 GiB entry-point-map reservation
+  removes misleading diagnostic noise without changing game execution.
 
 ## Work queue
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,6 +1,6 @@
 # Testing
 
-Last updated: 2026-08-11
+Last updated: 2026-09-01
 
 ## Principles
 
@@ -295,6 +295,25 @@ presence. Automated launch was backgrounded before runtime creation, so this is
 not a second gameplay acceptance pass. The recognized GCI was backed up before
 installation and read back byte-identical afterward at SHA-256
 `a8f5ea47227478c9acc010f9ba99fe5a0c493ff2e044c1f56b6a8952badce932`.
+
+On September 1, the iPhone 15 Pro reporter for Issue #12 supplied Preview 6
+report `SP-133DE3C9` and described the build as significantly more stable. The
+build-4 log confirms that the safety migration disabled the old 90% performance
+experiment and selected original 30 FPS, Original 4:3, and 1x on the A17 Pro at
+nominal thermals with Low Power Mode off. Five of six ten-second snapshots held
+29.9-30.0 FPS at 0.998-1.012 speed. One approximately one-second performance
+window reported 20.4 FPS / 0.969 speed while graphics resources were still
+rising, then recovered by the next snapshot and remained at 30 FPS. Resident
+memory levelled near 484 MiB. The report covers only about 80 seconds of runtime
+and contains no scene, frequency answer, or screenshot, so it is positive
+community hands-on evidence rather than long-session closure of Issue #12.
+
+The same report repeated two pre-existing startup messages. The memory-space
+error is the unused 64 GiB large-entry-map reservation inherited by
+StaticRecomp's empty invalidation cache; the follow-up mainline runtime disables
+that reservation on iOS. The one-time FEAT_AFP notice remains an ARM
+floating-point capability warning and is not correlated with the recovered
+slowdown sample. Neither message is evidence that iOS terminated the app.
 
 | Area | Current state | Required acceptance |
 |---|---|---|

--- a/patches/ModernGekko/0001-sunpad-apple-runtime.patch
+++ b/patches/ModernGekko/0001-sunpad-apple-runtime.patch
@@ -319,7 +319,7 @@ index 981e098..4c7e985 100644
  #ifdef _WIN32
    else
      impl->platform = Platform::CreateWin32Platform();
-@@ -267,12 +405,22 @@ RuntimeCreateResult Runtime::Create(RuntimeConfig config) {
+@@ -267,12 +405,27 @@ RuntimeCreateResult Runtime::Create(RuntimeConfig config) {
                           "the requested Dolphin host platform is unavailable"}};
    }
  
@@ -334,6 +334,11 @@ index 981e098..4c7e985 100644
 +  SetDolphinLogCallback(impl->config.log_callback, impl->config.log_user_data);
  
    Config::SetBase(Config::MAIN_CPU_CORE, PowerPC::CPUCore::StaticRecomp);
++#ifdef MODERNGEKKO_HAVE_IOS
++  // StaticRecomp's empty block cache only observes invalidations. It cannot
++  // use Dolphin's 64 GiB JIT entry-point map, which iOS refuses to reserve.
++  Config::SetBase(Config::MAIN_LARGE_ENTRY_POINTS_MAP, false);
++#endif
 +  if (impl->config.emulated_cpu_clock_scale)
 +  {
 +    Config::SetBase(Config::MAIN_OVERCLOCK_ENABLE, true);

--- a/scripts/check-repository.sh
+++ b/scripts/check-repository.sh
@@ -23,6 +23,7 @@ plutil -lint apple/ios/Info.plist apple/macos/Info.plist
 ./tests/test-controller-slots.sh
 ./tests/test-experimental-60fps-config.sh
 ./tests/test-experimental-performance-config.sh
+./tests/test-ios-staticrecomp-config.sh
 ./tests/test-generated-gmse01-audit.sh
 ./tests/test-diagnostics.sh
 ./tests/test-game-data-setup.sh

--- a/tests/test-ios-staticrecomp-config.sh
+++ b/tests/test-ios-staticrecomp-config.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+runtime_patch="$repo_root/patches/ModernGekko/0001-sunpad-apple-runtime.patch"
+runtime_source="$repo_root/ref/ModernGekko/src/runtime/dolphin_runtime.cpp"
+
+check_runtime_config() {
+  python3 - "$1" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+lines = path.read_text().splitlines()
+if path.suffix == ".patch":
+    lines = [line[1:] if line.startswith("+") and not line.startswith("+++") else line
+             for line in lines]
+text = "\n".join(lines)
+expected = """#ifdef MODERNGEKKO_HAVE_IOS
+  // StaticRecomp's empty block cache only observes invalidations. It cannot
+  // use Dolphin's 64 GiB JIT entry-point map, which iOS refuses to reserve.
+  Config::SetBase(Config::MAIN_LARGE_ENTRY_POINTS_MAP, false);
+#endif"""
+if expected not in text:
+    raise SystemExit(f"missing iOS-only StaticRecomp entry-map override in {path}")
+PY
+}
+
+check_runtime_config "$runtime_patch"
+if [[ -f "$runtime_source" ]]; then
+  check_runtime_config "$runtime_source"
+fi
+
+echo "iOS StaticRecomp configuration checks passed"


### PR DESCRIPTION
## Summary
- record the improved Preview 6 iPhone 15 Pro retest without closing the long-session slowdown
- disable the unused 64 GiB JIT entry-point map for iOS StaticRecomp
- add a focused regression check and update the canonical testing, status, known-issues, and technical-debt records

## Validation
- `./scripts/check-repository.sh`
- clean `git apply --check` against the pinned ModernGekko checkout
- `cmake --build ref/ModernGekko/build-ios-iphoneos-public --target moderngekko`